### PR TITLE
docs: fix OIDC auth verbiage & add links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ See the [samples](https://github.com/spectrocloud-labs/validator-plugin-aws/tree
 ## Authn & Authz
 Authentication details for the AWS validator controller are provided within each `AwsValidator` custom resource. AWS authentication can be configured either implicitly or explicitly. All supported options are detailed below:
 * Implicit (`AwsValidator.auth.implicit == true`)
-  * Node instance IAM role
-  * IMDSv2
+  * [IAM roles for Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+  * [IAM roles for Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html)
+  * [IAM roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) (OIDC)
 * Explicit (`AwsValidator.auth.implicit == false && AwsValidator.auth.secretName != ""`)
-  * Environment variables
-  * Environment variables + role assumption via AWS STS
+  * [Environment variables](https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#environment-variables)
+  * Environment variables + [role assumption via AWS STS](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/credentials/stscreds#AssumeRoleOptions)
 
 > [!NOTE]
 > See [values.yaml](https://github.com/spectrocloud-labs/validator-plugin-aws/tree/main/chart/validator-plugin-aws/values.yaml) for additional configuration details for each authentication option.

--- a/api/v1alpha1/awsvalidator_types.go
+++ b/api/v1alpha1/awsvalidator_types.go
@@ -41,7 +41,7 @@ func (s AwsValidatorSpec) ResultCount() int {
 
 type AwsAuth struct {
 	// If true, the AwsValidator will use the AWS SDK's default credential chain to authenticate.
-	// Set to true if using node instance IAM role or IMDSv2.
+	// Set to true if using node instance IAM role or IAM roles for Service Accounts.
 	Implicit bool `json:"implicit" yaml:"implicit"`
 	// Name of a Secret in the same namespace as the AwsValidator that contains AWS credentials.
 	// The secret data's keys and values are expected to align with valid AWS environment variable credentials,

--- a/chart/validator-plugin-aws/crds/validation.spectrocloud.labs_awsvalidators.yaml
+++ b/chart/validator-plugin-aws/crds/validation.spectrocloud.labs_awsvalidators.yaml
@@ -39,7 +39,7 @@ spec:
                   implicit:
                     description: If true, the AwsValidator will use the AWS SDK's
                       default credential chain to authenticate. Set to true if using
-                      node instance IAM role or IMDSv2.
+                      node instance IAM role or IAM roles for Service Accounts.
                     type: boolean
                   secretName:
                     description: Name of a Secret in the same namespace as the AwsValidator

--- a/chart/validator-plugin-aws/values.yaml
+++ b/chart/validator-plugin-aws/values.yaml
@@ -51,12 +51,12 @@ metricsService:
     targetPort: https
   type: ClusterIP
 auth:
-  # Leave secret undefined for implicit auth (node instance IAM role, IMDSv2, etc.)
+  # Leave secret undefined for implicit auth (node instance IAM role, IAM roles for Service Accounts, etc.)
   secret: {}
     # Specify the name of a secret in your cluster that contains AWS credentials.
     # E.g.: https://github.com/spectrocloud-labs/validator/blob/main/chart/validator/templates/plugin-secret-aws.yaml
     # secretName: aws-creds
 
-  # Override the service account used by AWS validator (optional, could be used for IMDSv2 on EKS)
+  # Override the service account used by AWS validator (optional, could be used for IAM roles for Service Accounts)
   # WARNING: the chosen service account must have the same RBAC privileges as seen in templates/manager-rbac.yaml
   serviceAccountName: ""

--- a/config/crd/bases/validation.spectrocloud.labs_awsvalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_awsvalidators.yaml
@@ -39,7 +39,7 @@ spec:
                   implicit:
                     description: If true, the AwsValidator will use the AWS SDK's
                       default credential chain to authenticate. Set to true if using
-                      node instance IAM role or IMDSv2.
+                      node instance IAM role or IAM roles for Service Accounts.
                     type: boolean
                   secretName:
                     description: Name of a Secret in the same namespace as the AwsValidator


### PR DESCRIPTION
I didn't understand IMDSv2 when I originally added those comments. I was mixed up between IMDSv2 and OIDC.

My updated understanding is that IMDSv2 is used transparently as part of the AWS SDK for Go's credential chain when checking for a node instance IAM role (and **only on EC2**). See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials.